### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "A small utility to handle content encoding with hyper"
 license = "MIT"
 keywords = ["http", "hyper", "content-encoding", "compression"]
 edition = "2021"
+repository = "https://github.com/Garfield1002/hyper-content-encoding"
 
 [dependencies]
 bytes = "1.6.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.